### PR TITLE
Add more arguments to build script

### DIFF
--- a/factory/images_builder.py
+++ b/factory/images_builder.py
@@ -99,7 +99,10 @@ def download_new_patch_and_build_kernel(version, arch):
                                        workdir="build/ghelper/"))
 
     factory.addStep(steps.ShellCommand(name="Building kernel",
-                                       command=["/bin/bash", "../build-kernel.sh", arch],
+                                       command=["/bin/bash", "../build-kernel.sh", arch,
+                                                util.Property('buildername'),
+                                                util.Property('buildnumber'),
+                                                "build/ghelper/linux-" + version + "/"],
                                        workdir="build/ghelper/linux-" + version + "/",
                                        logEnviron=False,
                                        haltOnFailure=True))


### PR DESCRIPTION
Build script will need to know build_name, build_number and source tree
path.

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>