### PR TITLE
Configure buildbotNetUsageData

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -100,6 +100,8 @@ c['titleURL'] = os.environ.get('GKERNELCI_TITLE_URL')
 
 c['buildbotURL'] = os.environ.get('GKERNELCI_URL')
 
+c['buildbotNetUsageData'] = None
+
 # minimalistic config to activate new web UI
 c['www'] = {
             'port': 8010,


### PR DESCRIPTION
buildbot complain on each startup to configure buildbotNetUsageData.
So let's set it to None to silent it.

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>