### PR TITLE
factory: fix unexpected keyword argument ['logenviron']

### DIFF
--- a/factory/images_builder.py
+++ b/factory/images_builder.py
@@ -196,8 +196,6 @@ def test_gentoo_sources(arch):
                                  command="date --iso-8601=ns",
                                  property="discoverytime"))
     factory.addStep(steps.SetProperty(
-                                 logEnviron=False,
-                                 name="set arch",
                                  property="arch",
                                  value=arch))
     factory.addStep(steps.GitHub(name="Fetching repository",


### PR DESCRIPTION
Signed-off-by: Alice Ferrazzi <alicef@gentoo.org>