### PR TITLE
config_stabilization: remove not for stable keywords

### DIFF
--- a/config_stabilization.yaml
+++ b/config_stabilization.yaml
@@ -14,9 +14,3 @@ architecture_stabilization_list:
  - name: ppc64le
    toolchain:
    - name: gcc
- - name: riscv64
-   toolchain:
-   - name: gcc
- - name: s390x
-   toolchain:
-   - name: gcc

--- a/settings.py
+++ b/settings.py
@@ -5,9 +5,9 @@ import yaml
 
 # Define branch to build
 branches_list = [
+    '6.2',
     '6.1',
     '6.0',
-    '5.19',
     '5.15', 
     '5.10', 
     '5.4', 


### PR DESCRIPTION
Signed-off-by: Alice Ferrazzi <alicef@gentoo.org>