### PR TITLE
stabilization: remove ppc64le as currently not working

### DIFF
--- a/config_stabilization.yaml
+++ b/config_stabilization.yaml
@@ -11,6 +11,3 @@ architecture_stabilization_list:
  - name: arm64
    toolchain:
    - name: gcc
- - name: ppc64le
-   toolchain:
-   - name: gcc


### PR DESCRIPTION
Signed-off-by: Alice Ferrazzi <alicef@gentoo.org>