### PR TITLE
Fixes for v4.3.0

### DIFF
--- a/factory/images_builder.py
+++ b/factory/images_builder.py
@@ -6,7 +6,6 @@ from buildbot.plugins import reporters, util
 from buildbot.process.properties import Interpolate
 from buildbot.steps.shell import ShellCommand
 from buildbot.process import results
-from buildbot.process.buildstep import LogLineObserver
 import re
 import pprint
 import os

--- a/master.cfg
+++ b/master.cfg
@@ -116,8 +116,7 @@ c['www'] = {
             'port': 8010,
             'plugins': { 'waterfall_view': True,
                          'console_view': True,
-                         'grid_view': True,
-                         'tyrian_view': True }
+                         'grid_view': True }
 }
 c['www']['authz'] = util.Authz(
     allowRules=[

--- a/sources.py
+++ b/sources.py
@@ -25,19 +25,9 @@ sources.append(
 sources.append(
     changes.GitPoller(
         repourl="https://anongit.gentoo.org/git/proj/linux-patches.git",
-        only_tags=True,
-        category="gentoo-tags-git",
-        workdir="linux-patches-tags",
-        pollInterval=300,
-    )
-)
-
-sources.append(
-    changes.GitPoller(
-        repourl="https://anongit.gentoo.org/git/proj/linux-patches.git",
         branches=True,
         category="gentoo-git",
-        workdir="linux-patches-branches",
+        workdir="linux-patches-git",
         pollInterval=300,
     )
 )

--- a/sources.py
+++ b/sources.py
@@ -18,7 +18,7 @@ sources.append(
         branches=True,
         category="gentoo-pull",
         workdir="gentoo-repository",
-        pollinterval=300,
+        pollInterval=300,
     )
 )
 
@@ -28,7 +28,7 @@ sources.append(
         only_tags=True,
         category="gentoo-tags-git",
         workdir="linux-patches-tags",
-        pollinterval=300,
+        pollInterval=300,
     )
 )
 
@@ -38,6 +38,6 @@ sources.append(
         branches=True,
         category="gentoo-git",
         workdir="linux-patches-branches",
-        pollinterval=300,
+        pollInterval=300,
     )
 )


### PR DESCRIPTION
This change comes with 4 separate commits each one marking a change from the v3 versions of buildbot to the v4 options of buildbot.

I didn't follow any special migration guides for this, I mostly just updated the versions in my dockerfiles and then fixed each problem sequentially. The result is that I have a working system that still has historical data, though I expect that there may be gaps in functionality.

One noteworthy diff is that I couldn't get the tyrian theme to work, so I disabled it. it's probably available in v4 as well, but I think we just need to pip3 install it in the virtualenv. 

Wait on merging this until I have the other PRs linked to this one.